### PR TITLE
Add padding values for printing on the Anycubic Vyper in PLA

### DIFF
--- a/framework-expansion-card-stand.scad
+++ b/framework-expansion-card-stand.scad
@@ -7,6 +7,10 @@ wall_thickness = 1.5;
 // depth = 32;
 // Mini version:
 depth = 10;
+
+// For printing on the Anycubic Vyper in PLA:
+// padding = 1.04;
+// Default:
 padding = 1.02;
 height = 6.9 * padding;
 width = 30 * padding;
@@ -14,6 +18,9 @@ width = 30 * padding;
 // For no base, set this to value smaller than USB-C plug depth:
 base_depth = 7.5;
 
+// For printing on the Anycubic Vyper in PLA:
+// plug_padding = 1.13;
+// Default:
 plug_padding = 1.03;
 usb_c_plug_width = 8.25 * plug_padding;
 usb_c_plug_height = 2.4 * plug_padding;


### PR DESCRIPTION
I printed this on an Anycubic Vyper in PLA. Default padding was to tight in my prints, so I got fitting values by trial and error.